### PR TITLE
Throw a ArgumentNullException in the constructor.

### DIFF
--- a/Jace/AstBuilder.cs
+++ b/Jace/AstBuilder.cs
@@ -18,6 +18,9 @@ namespace Jace
 
         public AstBuilder(IFunctionRegistry functionRegistry)
         {
+            if (functionRegistry == null)
+                throw new ArgumentNullException("functionRegistry");
+
             this.functionRegistry = functionRegistry;
 
             operationPrecedence.Add('(', 0);


### PR DESCRIPTION
Otherwise a NRE will be thrown later on in the Build() method, if AstBuilder was instanced with NULL.
