### PR TITLE
Variable case sensitivity option

### DIFF
--- a/Jace.Benchmark/Program.cs
+++ b/Jace.Benchmark/Program.cs
@@ -29,12 +29,20 @@ namespace Jace.Benchmark
             Console.WriteLine();
 
             Console.WriteLine("Interpreted Mode:");
-            CalculationEngine interpretedEngine = new CalculationEngine(CultureInfo.CurrentCulture, ExecutionMode.Interpreted);
+            CalculationEngine interpretedEngine = new CalculationEngine(CultureInfo.CurrentCulture, ExecutionMode.Interpreted, true, true, true);
             BenchMarkCalculationEngine(interpretedEngine, "2+3*7");
 
+            Console.WriteLine("Interpreted Mode(Case Sensitive):");
+            CalculationEngine interpretedEngineCaseSensitive = new CalculationEngine(CultureInfo.CurrentCulture, ExecutionMode.Interpreted, true, true, false);
+            BenchMarkCalculationEngine(interpretedEngineCaseSensitive, "2+3*7");
+
             Console.WriteLine("Compiled Mode:");
-            CalculationEngine compiledEngine = new CalculationEngine(CultureInfo.CurrentCulture, ExecutionMode.Compiled);
+            CalculationEngine compiledEngine = new CalculationEngine(CultureInfo.CurrentCulture, ExecutionMode.Compiled, true, true, true);
             BenchMarkCalculationEngine(compiledEngine, "2+3*7");
+
+            Console.WriteLine("Compiled Mode(Case Sensitive):");
+            CalculationEngine compiledEngineCaseSensitive = new CalculationEngine(CultureInfo.CurrentCulture, ExecutionMode.Compiled, true, true, false);
+            BenchMarkCalculationEngine(compiledEngineCaseSensitive, "2+3*7");
 
             Console.WriteLine("--------------------");
             Console.WriteLine("Function: {0}", "(var1 + var2 * 3)/(2+3) - something");
@@ -44,8 +52,14 @@ namespace Jace.Benchmark
             Console.WriteLine("Interpreted Mode:");
             BenchMarkCalculationEngineFunctionBuild(interpretedEngine, "(var1 + var2 * 3)/(2+3) - something");
 
+            Console.WriteLine("Interpreted Mode(Case Sensitive):");
+            BenchMarkCalculationEngineFunctionBuild(interpretedEngineCaseSensitive, "(var1 + var2 * 3)/(2+3) - something");
+
             Console.WriteLine("Compiled Mode:");
             BenchMarkCalculationEngineFunctionBuild(compiledEngine, "(var1 + var2 * 3)/(2+3) - something");
+
+            Console.WriteLine("Compiled Mode(Case Sensitive):");
+            BenchMarkCalculationEngineFunctionBuild(compiledEngineCaseSensitive, "(var1 + var2 * 3)/(2+3) - something");
 
             Console.WriteLine("--------------------");
             Console.WriteLine("Random Generated Functions: {0}", NumberOfFunctionsToGenerate.ToString("N0"));
@@ -60,8 +74,14 @@ namespace Jace.Benchmark
             Console.WriteLine("Interpreted Mode:");
             BenchMarkCalculationEngineRandomFunctionBuild(interpretedEngine, functions, NumberExecutionsPerRandomFunction);
 
+            Console.WriteLine("Interpreted Mode(Case Sensitive):");
+            BenchMarkCalculationEngineRandomFunctionBuild(interpretedEngineCaseSensitive, functions, NumberExecutionsPerRandomFunction);
+
             Console.WriteLine("Compiled Mode:");
             BenchMarkCalculationEngineRandomFunctionBuild(compiledEngine, functions, NumberExecutionsPerRandomFunction);
+
+            Console.WriteLine("Compiled Mode(Case Sensitive):");
+            BenchMarkCalculationEngineRandomFunctionBuild(compiledEngineCaseSensitive, functions, NumberExecutionsPerRandomFunction);
 
             Console.WriteLine("Press enter to exit...");
             Console.ReadLine();

--- a/Jace.DemoApp/MainWindow.xaml.cs
+++ b/Jace.DemoApp/MainWindow.xaml.cs
@@ -43,7 +43,7 @@ namespace Jace.DemoApp
 
                 IFunctionRegistry functionRegistry = new FunctionRegistry(false);
 
-                AstBuilder astBuilder = new AstBuilder(functionRegistry);
+                AstBuilder astBuilder = new AstBuilder(functionRegistry, true);
                 Operation operation = astBuilder.Build(tokens);
 
                 ShowAbstractSyntaxTree(operation);

--- a/Jace.Tests/AstBuilderTests.cs
+++ b/Jace.Tests/AstBuilderTests.cs
@@ -27,7 +27,7 @@ namespace Jace.Tests
         {
             IFunctionRegistry registry = new MockFunctionRegistry();
 
-            AstBuilder builder = new AstBuilder(registry);
+            AstBuilder builder = new AstBuilder(registry, true);
             Operation operation = builder.Build(new List<Token>() { 
                 new Token() { Value = '(', TokenType = TokenType.LeftBracket }, 
                 new Token() { Value = 42, TokenType = TokenType.Integer }, 
@@ -51,7 +51,7 @@ namespace Jace.Tests
         {
             IFunctionRegistry registry = new MockFunctionRegistry();
 
-            AstBuilder builder = new AstBuilder(registry);
+            AstBuilder builder = new AstBuilder(registry, true);
             Operation operation = builder.Build(new List<Token>() {
                 new Token() { Value = 2, TokenType = TokenType.Integer }, 
                 new Token() { Value = '+', TokenType = TokenType.Operation }, 
@@ -73,7 +73,7 @@ namespace Jace.Tests
         {
             IFunctionRegistry registry = new MockFunctionRegistry();
 
-            AstBuilder builder = new AstBuilder(registry);
+            AstBuilder builder = new AstBuilder(registry, true);
             Operation operation = builder.Build(new List<Token>() {
                 new Token() { Value = 2, TokenType = TokenType.Integer }, 
                 new Token() { Value = '*', TokenType = TokenType.Operation }, 
@@ -95,7 +95,7 @@ namespace Jace.Tests
         {
             IFunctionRegistry registry = new MockFunctionRegistry();
 
-            AstBuilder builder = new AstBuilder(registry);
+            AstBuilder builder = new AstBuilder(registry, true);
             Operation operation = builder.Build(new List<Token>() { 
                 new Token() { Value = 10, TokenType = TokenType.Integer }, 
                 new Token() { Value = '/', TokenType = TokenType.Operation }, 
@@ -115,7 +115,7 @@ namespace Jace.Tests
         {
             IFunctionRegistry registry = new MockFunctionRegistry();
 
-            AstBuilder builder = new AstBuilder(registry);
+            AstBuilder builder = new AstBuilder(registry, true);
             Operation operation = builder.Build(new List<Token>() { 
                 new Token() { Value = 10, TokenType = TokenType.Integer }, 
                 new Token() { Value = '*', TokenType = TokenType.Operation }, 
@@ -133,7 +133,7 @@ namespace Jace.Tests
         {
             IFunctionRegistry registry = new MockFunctionRegistry();
 
-            AstBuilder builder = new AstBuilder(registry);
+            AstBuilder builder = new AstBuilder(registry, true);
             Operation operation = builder.Build(new List<Token>() { 
                 new Token() { Value = 2, TokenType = TokenType.Integer }, 
                 new Token() { Value = '^', TokenType = TokenType.Operation }, 
@@ -151,7 +151,7 @@ namespace Jace.Tests
         {
             IFunctionRegistry registry = new MockFunctionRegistry();
 
-            AstBuilder builder = new AstBuilder(registry);
+            AstBuilder builder = new AstBuilder(registry, true);
             Operation operation = builder.Build(new List<Token>() { 
                 new Token() { Value = 2.7, TokenType = TokenType.FloatingPoint }, 
                 new Token() { Value = '%', TokenType = TokenType.Operation }, 
@@ -169,7 +169,7 @@ namespace Jace.Tests
         {
             IFunctionRegistry registry = new MockFunctionRegistry();
 
-            AstBuilder builder = new AstBuilder(registry);
+            AstBuilder builder = new AstBuilder(registry, true);
             Operation operation = builder.Build(new List<Token>() { 
                 new Token() { Value = 10, TokenType = TokenType.Integer }, 
                 new Token() { Value = '*', TokenType = TokenType.Operation }, 
@@ -187,7 +187,7 @@ namespace Jace.Tests
         {
             IFunctionRegistry registry = new MockFunctionRegistry();
 
-            AstBuilder builder = new AstBuilder(registry);
+            AstBuilder builder = new AstBuilder(registry, true);
             Operation operation = builder.Build(new List<Token>() { 
                 new Token() { Value = "var1", TokenType = TokenType.Text }, 
                 new Token() { Value = '+', TokenType = TokenType.Operation }, 
@@ -215,7 +215,7 @@ namespace Jace.Tests
         {
             IFunctionRegistry registry = new MockFunctionRegistry();
 
-            AstBuilder builder = new AstBuilder(registry);
+            AstBuilder builder = new AstBuilder(registry, true);
             Operation operation = builder.Build(new List<Token>() { 
                 new Token() { Value = "sin", TokenType = TokenType.Text }, 
                 new Token() { Value = '(', TokenType = TokenType.LeftBracket }, 
@@ -232,7 +232,7 @@ namespace Jace.Tests
         {
             IFunctionRegistry registry = new MockFunctionRegistry();
 
-            AstBuilder builder = new AstBuilder(registry);
+            AstBuilder builder = new AstBuilder(registry, true);
             Operation operation = builder.Build(new List<Token>() { 
                 new Token() { Value = "sin", TokenType = TokenType.Text }, 
                 new Token() { Value = '(', TokenType = TokenType.LeftBracket }, 
@@ -254,7 +254,7 @@ namespace Jace.Tests
         {
             IFunctionRegistry registry = new MockFunctionRegistry();
 
-            AstBuilder builder = new AstBuilder(registry);
+            AstBuilder builder = new AstBuilder(registry, true);
             Operation operation = builder.Build(new List<Token>() { 
                 new Token() { Value = "sin", TokenType = TokenType.Text }, 
                 new Token() { Value = '(', TokenType = TokenType.LeftBracket }, 
@@ -282,7 +282,7 @@ namespace Jace.Tests
         {
             IFunctionRegistry registry = new MockFunctionRegistry();
 
-            AstBuilder builder = new AstBuilder(registry);
+            AstBuilder builder = new AstBuilder(registry, true);
             Operation operation = builder.Build(new List<Token>() { 
                 new Token() { Value = 5.3, TokenType = TokenType.FloatingPoint }, 
                 new Token() { Value = '*', TokenType = TokenType.Operation}, 
@@ -309,7 +309,7 @@ namespace Jace.Tests
         {
             IFunctionRegistry registry = new MockFunctionRegistry();
 
-            AstBuilder builder = new AstBuilder(registry);
+            AstBuilder builder = new AstBuilder(registry, true);
 
             AssertExtensions.ThrowsException<ParseException>(() =>
                 {
@@ -329,7 +329,7 @@ namespace Jace.Tests
         {
             IFunctionRegistry registry = new MockFunctionRegistry();
 
-            AstBuilder builder = new AstBuilder(registry);
+            AstBuilder builder = new AstBuilder(registry, true);
 
             AssertExtensions.ThrowsException<ParseException>(() =>
                 {
@@ -349,7 +349,7 @@ namespace Jace.Tests
         {
             IFunctionRegistry registry = new MockFunctionRegistry();
 
-            AstBuilder builder = new AstBuilder(registry);
+            AstBuilder builder = new AstBuilder(registry, true);
 
             AssertExtensions.ThrowsException<ParseException>(() =>
                 {
@@ -367,7 +367,7 @@ namespace Jace.Tests
         {
             IFunctionRegistry registry = new MockFunctionRegistry();
 
-            AstBuilder builder = new AstBuilder(registry);
+            AstBuilder builder = new AstBuilder(registry, true);
 
             AssertExtensions.ThrowsException<ParseException>(() =>
                 {
@@ -385,7 +385,7 @@ namespace Jace.Tests
         {
             IFunctionRegistry registry = new MockFunctionRegistry();
 
-            AstBuilder builder = new AstBuilder(registry);
+            AstBuilder builder = new AstBuilder(registry, true);
 
             AssertExtensions.ThrowsException<ParseException>(() =>
                 {

--- a/Jace.Tests/CalculationEngineTests.cs
+++ b/Jace.Tests/CalculationEngineTests.cs
@@ -43,7 +43,7 @@ namespace Jace.Tests
         public void TestCalculateModuloCompiled()
         {
             CalculationEngine engine = 
-                new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, false, false);
+                new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, false, false, false);
             double result = engine.Calculate("5 % 3.0");
 
             Assert.AreEqual(2.0, result);
@@ -53,7 +53,7 @@ namespace Jace.Tests
         public void TestCalculateModuloInterpreted()
         {
             CalculationEngine engine = 
-                new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Interpreted, false, false);
+                new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Interpreted, false, false, false);
             double result = engine.Calculate("5 % 3.0");
 
             Assert.AreEqual(2.0, result);
@@ -128,7 +128,7 @@ namespace Jace.Tests
         [TestMethod]
         public void TestCalculateSineFunctionCompiled()
         {
-            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, true, false);
+            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, true, false, true);
             double result = engine.Calculate("sin(14)");
 
             Assert.AreEqual(Math.Sin(14.0), result);
@@ -146,7 +146,7 @@ namespace Jace.Tests
         [TestMethod]
         public void TestCalculateCosineFunctionCompiled()
         {
-            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, true, false);
+            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, true, false, true);
             double result = engine.Calculate("cos(41)");
 
             Assert.AreEqual(Math.Cos(41.0), result);
@@ -155,7 +155,7 @@ namespace Jace.Tests
         [TestMethod]
         public void TestCalculateLognFunctionInterpreted()
         {
-            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Interpreted, true, false);
+            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Interpreted, true, false, true);
             double result = engine.Calculate("logn(14, 3)");
 
             Assert.AreEqual(Math.Log(14.0, 3.0), result);
@@ -164,7 +164,7 @@ namespace Jace.Tests
         [TestMethod]
         public void TestCalculateLognFunctionCompiled()
         {
-            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, true, false);
+            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, true, false, true);
             double result = engine.Calculate("logn(14, 3)");
 
             Assert.AreEqual(Math.Log(14.0, 3.0), result);
@@ -173,7 +173,7 @@ namespace Jace.Tests
         [TestMethod]
         public void TestNegativeConstant()
         {
-            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, true, false);
+            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, true, false, true);
             double result = engine.Calculate("-100");
 
             Assert.AreEqual(-100.0, result);
@@ -182,7 +182,7 @@ namespace Jace.Tests
         [TestMethod]
         public void TestMultiplicationWithNegativeConstant()
         {
-            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, true, false);
+            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, true, false, true);
             double result = engine.Calculate("5*-100");
 
             Assert.AreEqual(-500.0, result);
@@ -191,7 +191,7 @@ namespace Jace.Tests
         [TestMethod]
         public void TestUnaryMinus1Compiled()
         {
-            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, true, false);
+            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, true, false, true);
             double result = engine.Calculate("-(1+2+(3+4))");
 
             Assert.AreEqual(-10.0, result);
@@ -200,7 +200,7 @@ namespace Jace.Tests
         [TestMethod]
         public void TestUnaryMinus1Interpreted()
         {
-            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Interpreted, true, false);
+            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Interpreted, true, false, true);
             double result = engine.Calculate("-(1+2+(3+4))");
 
             Assert.AreEqual(-10.0, result);
@@ -209,7 +209,7 @@ namespace Jace.Tests
         [TestMethod]
         public void TestUnaryMinus2Compiled()
         {
-            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, true, false);
+            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, true, false, true);
             double result = engine.Calculate("5+(-(1*2))");
 
             Assert.AreEqual(3.0, result);
@@ -218,7 +218,7 @@ namespace Jace.Tests
         [TestMethod]
         public void TestUnaryMinus2Interpreted()
         {
-            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Interpreted, true, false);
+            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Interpreted, true, false, true);
             double result = engine.Calculate("5+(-(1*2))");
 
             Assert.AreEqual(3.0, result);
@@ -227,7 +227,7 @@ namespace Jace.Tests
         [TestMethod]
         public void TestUnaryMinus3Compiled()
         {
-            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, true, false);
+            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, true, false, true);
             double result = engine.Calculate("5*(-(1*2)*3)");
 
             Assert.AreEqual(-30.0, result);
@@ -236,7 +236,7 @@ namespace Jace.Tests
         [TestMethod]
         public void TestUnaryMinus3Interpreted()
         {
-            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Interpreted, true, false);
+            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Interpreted, true, false, true);
             double result = engine.Calculate("5*(-(1*2)*3)");
 
             Assert.AreEqual(-30.0, result);
@@ -245,7 +245,7 @@ namespace Jace.Tests
         [TestMethod]
         public void TestUnaryMinus4Compiled()
         {
-            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, true, false);
+            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, true, false, true);
             double result = engine.Calculate("5* -(1*2)");
 
             Assert.AreEqual(-10.0, result);
@@ -254,7 +254,7 @@ namespace Jace.Tests
         [TestMethod]
         public void TestUnaryMinus4Interpreted()
         {
-            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Interpreted, true, false);
+            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Interpreted, true, false, true);
             double result = engine.Calculate("5* -(1*2)");
 
             Assert.AreEqual(-10.0, result);
@@ -263,7 +263,7 @@ namespace Jace.Tests
         [TestMethod]
         public void TestUnaryMinus5Compiled()
         {
-            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, true, false);
+            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, true, false, true);
             double result = engine.Calculate("-(1*2)^3");
 
             Assert.AreEqual(-8.0, result);
@@ -272,7 +272,7 @@ namespace Jace.Tests
         [TestMethod]
         public void TestUnaryMinus5Interpreted()
         {
-            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Interpreted, true, false);
+            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Interpreted, true, false, true);
             double result = engine.Calculate("-(1*2)^3");
 
             Assert.AreEqual(-8.0, result);
@@ -410,10 +410,34 @@ namespace Jace.Tests
         }
 
         [TestMethod]
+        public void TestVariableNameCaseSensitivityNoToLowerCompiled()
+        {
+          Dictionary<string, double> variables = new Dictionary<string, double>();
+          variables.Add("BlAbLa", 42.5);
+
+          CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, false, false, false);
+          double result = engine.Calculate("2 * BlAbLa", variables);
+
+          Assert.AreEqual(85.0, result);
+        }
+
+        [TestMethod]
+        public void TestVariableNameCaseSensitivityNoToLowerInterpreted()
+        {
+          Dictionary<string, double> variables = new Dictionary<string, double>();
+          variables.Add("BlAbLa", 42.5);
+
+          CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Interpreted, false, false, false);
+          double result = engine.Calculate("2 * BlAbLa", variables);
+
+          Assert.AreEqual(85.0, result);
+        }
+
+    [TestMethod]
         public void TestCustomFunctionInterpreted()
         {
             CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture,
-                ExecutionMode.Interpreted, false, false);
+                ExecutionMode.Interpreted, false, false, false);
             engine.AddFunction("test", (a, b) => a + b);
 
             double result = engine.Calculate("test(2,3)");
@@ -424,7 +448,7 @@ namespace Jace.Tests
         public void TestCustomFunctionCompiled()
         {
             CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture,
-                ExecutionMode.Compiled, false, false);
+                ExecutionMode.Compiled, false, false, false);
             engine.AddFunction("test", (a, b) => a + b);
 
             double result = engine.Calculate("test(2,3)");
@@ -738,7 +762,7 @@ namespace Jace.Tests
         public void TestCustomFunctionFunc11Interpreted()
         {
             CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture,
-                ExecutionMode.Interpreted, false, false);
+                ExecutionMode.Interpreted, false, false, false);
             engine.AddFunction("test", (a, b, c, d, e, f, g, h, i, j, k) => a + b + c + d + e + f + g + h + i + j + k);
             double result = engine.Calculate("test(1,2,3,4,5,6,7,8,9,10,11)");
             double expected = (11 * (11 + 1)) / 2.0;
@@ -749,7 +773,7 @@ namespace Jace.Tests
         public void TestCustomFunctionFunc11Compiled()
         {
             CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture,
-                ExecutionMode.Compiled, false, false);
+                ExecutionMode.Compiled, false, false, false);
             engine.AddFunction("test", (a, b, c, d, e, f, g, h, i, j, k) => a + b + c + d + e + f + g + h + i + j + k);
             double result = engine.Calculate("test(1,2,3,4,5,6,7,8,9,10,11)");
             double expected = (11 * (11 + 1)) / 2.0;
@@ -760,7 +784,7 @@ namespace Jace.Tests
         public void TestCustomFunctionDynamicFuncInterpreted()
         {
             CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture,
-                ExecutionMode.Interpreted, false, false);
+                ExecutionMode.Interpreted, false, false, false);
 
             double DoSomething(params double[] a)
             {
@@ -777,7 +801,7 @@ namespace Jace.Tests
         public void TestCustomFunctionDynamicFuncCompiled()
         {
             CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture,
-                ExecutionMode.Compiled, false, false);
+                ExecutionMode.Compiled, false, false, false);
 
             double DoSomething(params double[] a)
             {
@@ -794,7 +818,7 @@ namespace Jace.Tests
         public void TestCustomFunctionDynamicFuncNestedInterpreted()
         {
             CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture,
-                ExecutionMode.Interpreted, false, false);
+                ExecutionMode.Interpreted, false, false, false);
 
             double DoSomething(params double[] a)
             {
@@ -811,7 +835,7 @@ namespace Jace.Tests
         public void TestCustomFunctionDynamicFuncNestedDynamicCompiled()
         {
             CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture,
-                ExecutionMode.Compiled, false, false);
+                ExecutionMode.Compiled, false, false, false);
 
             double DoSomething(params double[] a)
             {

--- a/Jace.Tests/CalculationEngineTests.cs
+++ b/Jace.Tests/CalculationEngineTests.cs
@@ -91,6 +91,36 @@ namespace Jace.Tests
         }
 
         [TestMethod]
+        public void TestCalculateFormulaWithCaseSensitiveVariablesCompiled()
+        {
+            Dictionary<string, double> variables = new Dictionary<string, double>();
+            variables.Add("VaR1", 2.5);
+            variables.Add("vAr2", 3.4);
+            variables.Add("var1", 1);
+            variables.Add("var2", 1);
+
+            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Compiled, false, false, false);
+            double result = engine.Calculate("VaR1*vAr2", variables);
+
+            Assert.AreEqual(8.5, result);
+        }
+
+        [TestMethod]
+        public void TestCalculateFormulaWithCaseSensitiveVariablesInterpreted()
+        {
+            Dictionary<string, double> variables = new Dictionary<string, double>();
+            variables.Add("VaR1", 2.5);
+            variables.Add("vAr2", 3.4);
+            variables.Add("var1", 1);
+            variables.Add("var2", 1);
+
+            CalculationEngine engine = new CalculationEngine(CultureInfo.InvariantCulture, ExecutionMode.Interpreted, false, false, false);
+            double result = engine.Calculate("VaR1*vAr2", variables);
+
+            Assert.AreEqual(8.5, result);
+        }
+
+        [TestMethod]
         public void TestCalculateFormulaVariableNotDefinedInterpreted()
         {
             Dictionary<string, double> variables = new Dictionary<string, double>();

--- a/Jace/AstBuilder.cs
+++ b/Jace/AstBuilder.cs
@@ -11,18 +11,19 @@ namespace Jace
     public class AstBuilder
     {
         private readonly IFunctionRegistry functionRegistry;
-
+        private readonly bool adjustVariableCaseEnabled;
         private Dictionary<char, int> operationPrecedence = new Dictionary<char, int>();
         private Stack<Operation> resultStack = new Stack<Operation>();
         private Stack<Token> operatorStack = new Stack<Token>();
         private Stack<int> parameterCount = new Stack<int>();
 
-        public AstBuilder(IFunctionRegistry functionRegistry)
+        public AstBuilder(IFunctionRegistry functionRegistry, bool adjustVariableCaseEnabled)
         {
             if (functionRegistry == null)
                 throw new ArgumentNullException("functionRegistry");
 
             this.functionRegistry = functionRegistry;
+            this.adjustVariableCaseEnabled = adjustVariableCaseEnabled;
 
             operationPrecedence.Add('(', 0);
             operationPrecedence.Add('<', 1);
@@ -67,7 +68,12 @@ namespace Jace
                         }
                         else
                         {
-                            resultStack.Push(new Variable(((string)token.Value).ToLowerInvariant()));
+                            string tokenValue = (string)token.Value;
+                            if (adjustVariableCaseEnabled)
+                            {
+                              tokenValue = tokenValue.ToLowerInvariant();
+                            }
+                            resultStack.Push(new Variable(tokenValue));
                         }
                         break;
                     case TokenType.LeftBracket:

--- a/Jace/CalculationEngine.cs
+++ b/Jace/CalculationEngine.cs
@@ -26,11 +26,12 @@ namespace Jace
         private readonly bool cacheEnabled;
         private readonly bool optimizerEnabled;
         private readonly bool adjustVariableCaseEnabled;
+
         /// <summary>
         /// Creates a new instance of the <see cref="CalculationEngine"/> class with
         /// default parameters.
         /// </summary>
-    public CalculationEngine()
+        public CalculationEngine()
             : this(CultureInfo.CurrentCulture, ExecutionMode.Compiled)
         {
         }

--- a/Jace/CalculationEngine.cs
+++ b/Jace/CalculationEngine.cs
@@ -25,12 +25,12 @@ namespace Jace
         private readonly MemoryCache<string, Func<IDictionary<string, double>, double>> executionFormulaCache;
         private readonly bool cacheEnabled;
         private readonly bool optimizerEnabled;
-
+        private readonly bool adjustVariableCaseEnabled;
         /// <summary>
         /// Creates a new instance of the <see cref="CalculationEngine"/> class with
         /// default parameters.
         /// </summary>
-        public CalculationEngine()
+    public CalculationEngine()
             : this(CultureInfo.CurrentCulture, ExecutionMode.Compiled)
         {
         }
@@ -56,21 +56,22 @@ namespace Jace
         /// </param>
         /// <param name="executionMode">The execution mode that must be used for formula execution.</param>
         public CalculationEngine(CultureInfo cultureInfo, ExecutionMode executionMode)
-            : this(cultureInfo, executionMode, true, true) 
+            : this(cultureInfo, executionMode, true, true, true) 
         {
         }
 
-        /// <summary>
-        /// Creates a new instance of the <see cref="CalculationEngine"/> class.
-        /// </summary>
-        /// <param name="cultureInfo">
-        /// The <see cref="CultureInfo"/> required for correctly reading floating poin numbers.
-        /// </param>
-        /// <param name="executionMode">The execution mode that must be used for formula execution.</param>
-        /// <param name="cacheEnabled">Enable or disable caching of mathematical formulas.</param>
-        /// <param name="optimizerEnabled">Enable or disable optimizing of formulas.</param>
-        public CalculationEngine(CultureInfo cultureInfo, ExecutionMode executionMode, bool cacheEnabled, bool optimizerEnabled)
-            : this(cultureInfo, executionMode, cacheEnabled, optimizerEnabled, true, true)
+    /// <summary>
+    /// Creates a new instance of the <see cref="CalculationEngine"/> class.
+    /// </summary>
+    /// <param name="cultureInfo">
+    /// The <see cref="CultureInfo"/> required for correctly reading floating poin numbers.
+    /// </param>
+    /// <param name="executionMode">The execution mode that must be used for formula execution.</param>
+    /// <param name="cacheEnabled">Enable or disable caching of mathematical formulas.</param>
+    /// <param name="optimizerEnabled">Enable or disable optimizing of formulas.</param>
+    /// <param name="adjustVariableCaseEnabled">Enable or disable auto lowercasing of variables.</param>
+    public CalculationEngine(CultureInfo cultureInfo, ExecutionMode executionMode, bool cacheEnabled, bool optimizerEnabled, bool adjustVariableCaseEnabled)
+            : this(cultureInfo, executionMode, cacheEnabled, optimizerEnabled, adjustVariableCaseEnabled, true, true)
         {
         }
 
@@ -86,7 +87,7 @@ namespace Jace
         /// <param name="defaultFunctions">Enable or disable the default functions.</param>
         /// <param name="defaultConstants">Enable or disable the default constants.</param>
         public CalculationEngine(CultureInfo cultureInfo, ExecutionMode executionMode, bool cacheEnabled, 
-            bool optimizerEnabled, bool defaultFunctions, bool defaultConstants)
+            bool optimizerEnabled, bool adjustVariableCaseEnabled, bool defaultFunctions, bool defaultConstants)
         {
             this.executionFormulaCache = new MemoryCache<string, Func<IDictionary<string, double>, double>>();
             this.FunctionRegistry = new FunctionRegistry(false);
@@ -94,11 +95,12 @@ namespace Jace
             this.cultureInfo = cultureInfo;
             this.cacheEnabled = cacheEnabled;
             this.optimizerEnabled = optimizerEnabled;
+            this.adjustVariableCaseEnabled = adjustVariableCaseEnabled;
 
             if (executionMode == ExecutionMode.Interpreted)
-                executor = new Interpreter();
+                executor = new Interpreter(adjustVariableCaseEnabled);
             else if (executionMode == ExecutionMode.Compiled)
-                executor = new DynamicCompiler();
+                executor = new DynamicCompiler(adjustVariableCaseEnabled);
             else
                 throw new ArgumentException(string.Format("Unsupported execution mode \"{0}\".", executionMode), 
                     "executionMode");
@@ -135,8 +137,10 @@ namespace Jace
             if (variables == null)
                 throw new ArgumentNullException("variables");
 
-            
-            variables = EngineUtil.ConvertVariableNamesToLowerCase(variables);
+            if (adjustVariableCaseEnabled)
+            {
+              variables = EngineUtil.ConvertVariableNamesToLowerCase(variables);
+            }
             VerifyVariableNames(variables);
 
             // Add the reserved variables to the dictionary
@@ -365,7 +369,7 @@ namespace Jace
             TokenReader tokenReader = new TokenReader(cultureInfo);
             List<Token> tokens = tokenReader.Read(formulaText);
 
-            AstBuilder astBuilder = new AstBuilder(FunctionRegistry);
+            AstBuilder astBuilder = new AstBuilder(FunctionRegistry, adjustVariableCaseEnabled);
             Operation operation = astBuilder.Build(tokens);
 
             if (optimizerEnabled)

--- a/Jace/Execution/Interpreter.cs
+++ b/Jace/Execution/Interpreter.cs
@@ -10,14 +10,27 @@ namespace Jace.Execution
 {
     public class Interpreter : IExecutor
     {
+        private readonly bool adjustVariableCaseEnabled;
+
+        public Interpreter(): this(true) { }
+
+        public Interpreter(bool adjustVariableCaseEnabled)
+        {
+            this.adjustVariableCaseEnabled = adjustVariableCaseEnabled;
+        }
         public Func<IDictionary<string, double>, double> BuildFormula(Operation operation, 
             IFunctionRegistry functionRegistry)
-        { 
-            return variables =>
-                {
-                    variables = EngineUtil.ConvertVariableNamesToLowerCase(variables);
-                    return Execute(operation, functionRegistry, variables);
-                };
+        {
+            return adjustVariableCaseEnabled
+              ? (Func<IDictionary<string, double>, double>)(variables =>
+              {
+                variables = EngineUtil.ConvertVariableNamesToLowerCase(variables);
+                return Execute(operation, functionRegistry, variables);
+              })
+              : (Func<IDictionary<string, double>, double>)(variables =>
+              {
+                return Execute(operation, functionRegistry, variables);
+              });
         }
 
         public double Execute(Operation operation, IFunctionRegistry functionRegistry)


### PR DESCRIPTION
# Description
Provides the user the ability to specify the case sensitivity of the calculation engine by passing a bool into the CalculationEngine constructor similar to how caching and optimization are controlled.

The default behavior is maintained by electing to be case insensitive by default.

Fixes #35 related to performance when forcing case insensitive evaluations.

# Testing

- Updated all existing tests to ensure functionality remained intact
- Added two tests to verify correctly cased version of variable was selected in all modes.
- Added two tests to ensure that when only mixed case variable is defined engine operated as expected in all modes.

# Benchmarking
```
Jace.NET Benchmark Application

--------------------
Function: 2+3*7/23
Number Of Tests: 1,000,000

Interpreted Mode:
Total duration: 00:00:01.6416091
Interpreted Mode(Case Sensitive):
Total duration: 00:00:00.7719340
Compiled Mode:
Total duration: 00:00:01.3015149
Compiled Mode(Case Sensitive):
Total duration: 00:00:00.6403131
--------------------
Function: (var1 + var2 * 3)/(2+3) - something
Number Of Tests: 1,000,000

Interpreted Mode:
Total duration: 00:00:07.2805178
Interpreted Mode(Case Sensitive):
Total duration: 00:00:05.6568951
Compiled Mode:
Total duration: 00:00:06.2263400
Compiled Mode(Case Sensitive):
Total duration: 00:00:04.4839689
--------------------
Random Generated Functions: 10,000
Number Of Variables Of Each Function: 3
Number Of Executions For Each Function: 1,000
Total Number Of Executions: 10,000,000
Parallel: True

Interpreted Mode:
Total duration: 00:00:31.7136317
Interpreted Mode(Case Sensitive):
Total duration: 00:00:23.6118180
Compiled Mode:
Total duration: 00:00:32.5888003
Compiled Mode(Case Sensitive):
Total duration: 00:00:24.7407965
Press enter to exit...


Test 1:
    Interpreted: 52.98% Speed up when operating as case sensitive
    Compiled: 50.80% Speed up when operating as case sensitive
Test 2:
    Interpreted: 22.3% Speed up when operating as case sensitive
    Compiled: 27.98% Speed up when operating as case sensitive
Test 3:
    Interpreted: 25.55% Speed up when operating as case sensitive
    Compiled: 24.08% Speed up when operating as case sensitive
```