### PR TITLE
Adds support for configuring the memory cache thresholds

### DIFF
--- a/Jace/CalculationEngine.cs
+++ b/Jace/CalculationEngine.cs
@@ -72,7 +72,7 @@ namespace Jace
         /// <param name="optimizerEnabled">Enable or disable optimizing of formulas.</param>
         /// <param name="adjustVariableCaseEnabled">Enable or disable auto lowercasing of variables.</param>
         public CalculationEngine(CultureInfo cultureInfo, ExecutionMode executionMode, bool cacheEnabled, bool optimizerEnabled, bool adjustVariableCaseEnabled)
-            : this(cultureInfo, executionMode, cacheEnabled, optimizerEnabled, adjustVariableCaseEnabled, true, true)
+            : this(cultureInfo, executionMode, cacheEnabled, optimizerEnabled, adjustVariableCaseEnabled, true, true, JaceOptions.DefaultCacheMaximumSize, JaceOptions.DefaultCacheReductionSize)
         {
         }
 
@@ -82,7 +82,7 @@ namespace Jace
         /// <param name="options">The <see cref="JaceOptions"/> to configure the behaviour of the engine.</param>
         public CalculationEngine(JaceOptions options)
             : this(options.CultureInfo, options.ExecutionMode, options.CacheEnabled, options.OptimizerEnabled, options.AdjustVariableCase,
-                  options.DefaultFunctions, options.DefaultConstants)
+                  options.DefaultFunctions, options.DefaultConstants, options.CacheMaximumSize, options.CacheReductionSize)
         {
         }
 
@@ -98,9 +98,9 @@ namespace Jace
         /// <param name="defaultFunctions">Enable or disable the default functions.</param>
         /// <param name="defaultConstants">Enable or disable the default constants.</param>
         public CalculationEngine(CultureInfo cultureInfo, ExecutionMode executionMode, bool cacheEnabled, 
-            bool optimizerEnabled, bool adjustVariableCaseEnabled, bool defaultFunctions, bool defaultConstants)
+            bool optimizerEnabled, bool adjustVariableCaseEnabled, bool defaultFunctions, bool defaultConstants, int cacheMaximumSize, int cacheReductionSize)
         {
-            this.executionFormulaCache = new MemoryCache<string, Func<IDictionary<string, double>, double>>();
+            this.executionFormulaCache = new MemoryCache<string, Func<IDictionary<string, double>, double>>(cacheMaximumSize, cacheReductionSize);
             this.FunctionRegistry = new FunctionRegistry(false);
             this.ConstantRegistry = new ConstantRegistry(false);
             this.cultureInfo = cultureInfo;

--- a/Jace/JaceOptions.cs
+++ b/Jace/JaceOptions.cs
@@ -8,6 +8,9 @@ namespace Jace
 {
     public class JaceOptions
     {
+        internal const int DefaultCacheMaximumSize = 500;
+        internal const int DefaultCacheReductionSize = 50;
+
         public JaceOptions()
         {
             CultureInfo = CultureInfo.CurrentCulture;
@@ -17,11 +20,15 @@ namespace Jace
             AdjustVariableCase = true;
             DefaultFunctions = true;
             DefaultConstants = true;
+            CacheMaximumSize = DefaultCacheMaximumSize;
+            CacheReductionSize = DefaultCacheReductionSize;
         }
 
         public CultureInfo CultureInfo { get; set; }
         public ExecutionMode ExecutionMode { get; set; }
         public bool CacheEnabled { get; set; }
+        public int CacheMaximumSize { get; set; }
+        public int CacheReductionSize { get; set; }
         public bool OptimizerEnabled { get; set; }
         public bool AdjustVariableCase { get; private set; }
         public bool DefaultFunctions { get; set; }

--- a/Jace/Util/MemoryCache.cs
+++ b/Jace/Util/MemoryCache.cs
@@ -15,23 +15,12 @@ namespace Jace.Util
     /// <typeparam name="TValue">The type of the values.</typeparam>
     public class MemoryCache<TKey, TValue>
     {
-        private const int DefaultMaximumSize = 500;
-        private const int DefaultReductionSize = 50;
-
         private readonly int maximumSize;
         private readonly int reductionSize;
 
         private long counter; // We cannot use DateTime.Now, because the precission is not high enough.
 
         private readonly ConcurrentDictionary<TKey, CacheItem> dictionary;
-
-        /// <summary>
-        /// Create a new instance of the <see cref="MemoryCache"/>.
-        /// </summary>
-        public MemoryCache()
-            : this(DefaultMaximumSize, DefaultReductionSize)
-        {
-        }
 
         /// <summary>
         /// Create a new instance of the <see cref="MemoryCache"/>.


### PR DESCRIPTION
We have the need of being able to change the thresholds values in the MemoryCache.

I wasn't sure exactly how to do with the constructors and JaceOptions.
In this implementation, I did the least viable adding it to the options and to the constructor that takes all settings.

I was thinking about changing it a little bit making the constructor taking the options object to be the one configuring everything bit deemed it to more changes than needed maybe?

That change would however not had needed to break any contract.