### PR TITLE
Fix issue with custom functions compiled from expressions

### DIFF
--- a/Jace/Execution/FunctionRegistry.cs
+++ b/Jace/Execution/FunctionRegistry.cs
@@ -62,7 +62,10 @@ namespace Jace.Execution
                     if (genericArgument != typeof(double))
                         throw new ArgumentException("Only doubles are supported as function arguments.", "function");
 
-                numberOfParameters = function.GetMethodInfo().GetParameters().Length;
+                numberOfParameters = function
+                    .GetMethodInfo()
+                    .GetParameters()
+                    .Count(p => p.ParameterType == typeof(double));
             }
             else if (funcType.FullName.StartsWith(DynamicFuncName))
             {


### PR DESCRIPTION
When a function is compiled from an expression during runtime
the .NET framework adds a "hidden" parameter to the function
of type ClosureInfo. This is an internal compiler detail but
it is exposed when fetching the parameters from the MethodInfo.
This causes Jace to think there is an extra parameter when the
compiled expression is used as a custom function.