### PR TITLE
don't generate a new string instance when not needed

### DIFF
--- a/Jace/Util/EngineUtil.cs
+++ b/Jace/Util/EngineUtil.cs
@@ -25,7 +25,7 @@ namespace Jace.Util
         static internal string ToLowerFast(this string text)
         {
             StringBuilder buffer = new StringBuilder(text.Length);
-
+            bool modified = false;
             for(int i = 0; i < text.Length; i++)
             {
                 char c = text[i];
@@ -33,6 +33,7 @@ namespace Jace.Util
                 if (c >= 'A' && c <= 'Z')
                 {
                     buffer.Append((char)(c + 32));
+                    modified = true;
                 }
                 else 
                 {
@@ -40,7 +41,7 @@ namespace Jace.Util
                 }
             }
 
-            return buffer.ToString();
+            return modified ? buffer.ToString() : text;
         }
     }
 }


### PR DESCRIPTION
when adding functions to the FunctionRegistry, it generates excessive strings when they are already lower case.  This avoids that.