### PR TITLE
added sum function to FunctionRegistry

### DIFF
--- a/Jace/CalculationEngine.cs
+++ b/Jace/CalculationEngine.cs
@@ -414,6 +414,7 @@ namespace Jace
             FunctionRegistry.RegisterFunction("min", (DynamicFunc<double, double>)((a) => a.Min()), true, false);
             FunctionRegistry.RegisterFunction("avg", (DynamicFunc<double, double>)((a) => a.Average()), true, false);
             FunctionRegistry.RegisterFunction("median", (DynamicFunc<double, double>)((a) => MathExtended.Median(a)), true, false);
+            FunctionRegistry.RegisterFunction("sum", (DynamicFunc<double, double>)((a) => a.Sum()), true, false);
 
             // Non Idempotent Functions
             FunctionRegistry.RegisterFunction("random", (Func<double>)random.NextDouble, false, false);


### PR DESCRIPTION
With this one-line change, users can use the "sum" function. The function takes a variable amount of arguments delimited by a comma, then outputs the sum of the arguments.